### PR TITLE
Remove outdated relay nodes from lidar wrapper

### DIFF
--- a/velodyne_lidar_driver_wrapper/launch/velodyne_lidar_wrapper.launch
+++ b/velodyne_lidar_driver_wrapper/launch/velodyne_lidar_wrapper.launch
@@ -20,7 +20,4 @@
 <launch>
     <node name="velodyne_lidar_driver_wrapper" pkg="velodyne_lidar_driver_wrapper" type="velodyne_lidar_driver_wrapper_node" output="screen"/>
     <rosparam command="load" file="$(find velodyne_lidar_driver_wrapper)/config/parameters.yaml" />
-
-    <node pkg="topic_tools" type="relay" name="relay_points_raw" args="velodyne_points lidar/points_raw" />
-    <node pkg="topic_tools" type="relay" name="relay_lidar_scan" args="scan lidar/scan" />
 </launch>


### PR DESCRIPTION
Resolves 
usdot-fhwa-stol/CARMAPlatform#337

Relay nodes were duplicating lidar data onto these topics. This removes those nodes as that functionality is handled by remapping. 