### PR TITLE
Update base image version for carma-base component release 3.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
     # Pull docker image from docker hub
     # XTERM used for better catkin_make output
     docker:
-      - image: usdotfhwastol/carma-base:3.3.0
+      - image: usdotfhwastol/carma-base:3.4.0
         user: carma
         environment:
           TERM: xterm # use xterm to get full display output from build

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY --chown=carma . /home/carma/src/
 RUN ~/src/docker/checkout.sh
 RUN ~/src/docker/install.sh
 
-FROM usdotfhwastol/carma-base:3.3.0
+FROM usdotfhwastol/carma-base:3.4.0
 
 ARG BUILD_DATE="NULL"
 ARG VERSION="NULL"


### PR DESCRIPTION
Update base image version for carma-base component release 3.4.0
Helps address: usdot-fhwa-stol/CARMAPlatform#419