### PR TITLE
Feature/truck config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,14 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 
-FROM usdotfhwastol/carma-base:3.4.0 as setup
+FROM usdotfhwastol/autoware.ai:3.4.0 as setup
 
 RUN mkdir ~/src
 COPY --chown=carma . /home/carma/src/
 RUN ~/src/docker/checkout.sh
 RUN ~/src/docker/install.sh
 
-FROM usdotfhwastol/carma-base:3.4.0
+FROM usdotfhwastol/autoware.ai:3.4.0
 
 ARG BUILD_DATE="NULL"
 ARG VERSION="NULL"

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -15,6 +15,7 @@
 #  the License.
 
 sudo chmod -R +x /opt/carma/install
-source /opt/ros/kinetic/setup.bash
+source /opt/autoware.ai/ros/install/setup.bash
+export ROS_LANG_DISABLE=genjava # Disable genjava as it is not needed in this image and makes build inconsistent 
 cd ~/
 catkin_make install

--- a/velodyne_lidar_driver_wrapper/launch/velodyne_lidar_driver.launch
+++ b/velodyne_lidar_driver_wrapper/launch/velodyne_lidar_driver.launch
@@ -21,6 +21,8 @@
 
   <arg name="frame_id" default="velodyne" doc="The frame id to use for the scan data"/>
   <arg name="device_ip" default="192.168.1.201" doc="Ip address of velodyne device"/>
+  <arg name="max_range" default="200" doc="Maximum lidar range in meters"/>
+  <arg name="port" default="2368" doc="Communication port of lidar"/>
 
   <!-- Launch Wrapper -->
   <remap from="velodyne_points" to="lidar/points_raw"/>
@@ -30,6 +32,8 @@
   <include file="$(find velodyne_pointcloud)/launch/VLP-32C_points.launch">
     <arg name="frame_id" value="$(arg frame_id)" />
     <arg name="device_ip" value="$(arg device_ip)" />
+    <arg name="max_range" value="$(arg max_range)" />
+    <arg name="port" value="$(arg port)" />
   </include>
 
 </launch>


### PR DESCRIPTION
This PR updates this driver to be compatible with the Freightliner Cascadia configuration used at STOL. The following changes are made
- Docker file and install.sh updated to depend on the autoware.ai image. This allows for use of the lidar concat node. 
- The velodyne_lidar_driver.launch file is updated to expose the port and max_range arguments 

Helps address usdot-fhwa-stol/CARMAPlatform#489