### PR TITLE
updated copyright info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-#  Copyright (C) 2018-2019 LEIDOS.
+#  Copyright (C) 2018-2020 LEIDOS.
 # 
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of

--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#  Copyright (C) 2018-2019 LEIDOS.
+#  Copyright (C) 2018-2020 LEIDOS.
 # 
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of

--- a/docker/checkout.sh
+++ b/docker/checkout.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#  Copyright (C) 2018-2019 LEIDOS.
+#  Copyright (C) 2018-2020 LEIDOS.
 # 
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of

--- a/docker/get-component-version.sh
+++ b/docker/get-component-version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#  Copyright (C) 2018-2019 LEIDOS.
+#  Copyright (C) 2018-2020 LEIDOS.
 # 
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of

--- a/docker/get-image-name.sh
+++ b/docker/get-image-name.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#  Copyright (C) 2018-2019 LEIDOS.
+#  Copyright (C) 2018-2020 LEIDOS.
 # 
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of

--- a/docker/get-repo-name.sh
+++ b/docker/get-repo-name.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#  Copyright (C) 2018-2019 LEIDOS.
+#  Copyright (C) 2018-2020 LEIDOS.
 # 
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of

--- a/docker/get-system-version.sh
+++ b/docker/get-system-version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#  Copyright (C) 2018-2019 LEIDOS.
+#  Copyright (C) 2018-2020 LEIDOS.
 # 
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#  Copyright (C) 2018-2019 LEIDOS.
+#  Copyright (C) 2018-2020 LEIDOS.
 # 
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of

--- a/velodyne_lidar_driver_wrapper/include/velodyne_lidar_driver_wrapper.h
+++ b/velodyne_lidar_driver_wrapper/include/velodyne_lidar_driver_wrapper.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- * Copyright (C) 2019 LEIDOS.
+ * Copyright (C) 2019-2020 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/velodyne_lidar_driver_wrapper/launch/velodyne_lidar_driver.launch
+++ b/velodyne_lidar_driver_wrapper/launch/velodyne_lidar_driver.launch
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  Copyright (C) 2018-2019 LEIDOS.
+  Copyright (C) 2018-2020 LEIDOS.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/velodyne_lidar_driver_wrapper/launch/velodyne_lidar_wrapper.launch
+++ b/velodyne_lidar_driver_wrapper/launch/velodyne_lidar_wrapper.launch
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  Copyright (C) 2018-2019 LEIDOS.
+  Copyright (C) 2018-2020 LEIDOS.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/velodyne_lidar_driver_wrapper/src/main.cpp
+++ b/velodyne_lidar_driver_wrapper/src/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 LEIDOS.
+ * Copyright (C) 2019-2020 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/velodyne_lidar_driver_wrapper/src/velodyne_lidar_driver_wrapper.cpp
+++ b/velodyne_lidar_driver_wrapper/src/velodyne_lidar_driver_wrapper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 LEIDOS.
+ * Copyright (C) 2019-2020 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of


### PR DESCRIPTION
PR to update copyright info in develop, tested by building docker image per CAR-1532.
![velodyne](https://user-images.githubusercontent.com/57960283/71983758-781aeb00-31f5-11ea-82d8-1e7ce9e283fc.png)
