### PR TITLE
Correct autoware version in base docker image to 3.6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
     # Pull docker image from docker hub
     # XTERM used for better catkin_make output
     docker:
-      - image: usdotfhwastol/carma-base:3.6.0
+      - image: usdotfhwastol/autoware.ai:3.6.0
         user: carma
         environment:
           TERM: xterm # use xterm to get full display output from build

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,14 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 
-FROM usdotfhwastol/autoware.ai:3.5.0 as setup
+FROM usdotfhwastol/autoware.ai:3.6.0 as setup
 
 RUN mkdir ~/src
 COPY --chown=carma . /home/carma/src/
 RUN ~/src/docker/checkout.sh
 RUN ~/src/docker/install.sh
 
-FROM usdotfhwastol/autoware.ai:3.5.0
+FROM usdotfhwastol/autoware.ai:3.6.0
 
 ARG BUILD_DATE="NULL"
 ARG VERSION="NULL"

--- a/velodyne_lidar_driver_wrapper/package.xml
+++ b/velodyne_lidar_driver_wrapper/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>velodyne_lidar_driver_wrapper</name>
-  <version>1.2.0</version>
+  <version>1.3.0</version>
   <description>CARMA velodyne lidar driver wrapper package</description>
   <maintainer email="carma@todo.todo">carma</maintainer>
   <license>Apache 2.0</license>


### PR DESCRIPTION
This PR updates the base docker images to use the new component release of the autoware.ai repo version 3.6.0.

This is in support of usdot-fhwa-stol/CARMAPlatform#333